### PR TITLE
Add disposable onCancel/onAttach/onDetach callbacks.

### DIFF
--- a/mvnvm.properties
+++ b/mvnvm.properties
@@ -1,0 +1,1 @@
+mvn_version=3.3.9

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>com.groupon.jtier</groupId>
     <artifactId>jtier-ctx</artifactId>
     <packaging>jar</packaging>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <name>Ctx</name>
 
     <scm>

--- a/src/main/java/com/groupon/jtier/Disposable.java
+++ b/src/main/java/com/groupon/jtier/Disposable.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.groupon.jtier;
+
+/**
+ * Objects of this type are returned from the {@link Ctx#onAttach(Runnable)},
+ * {@link Ctx#onCancel(Runnable)} and {@link Ctx#onDetach(Runnable)} methods of {@link Ctx}.
+ * <p>
+ * The {@link #dispose()} method will remove that callback from the Ctx.
+ */
+@FunctionalInterface
+public interface Disposable {
+    /**
+     * Disposes a callback. Behavior is undefined if invoked more than once.
+     */
+    void dispose();
+}

--- a/src/main/java/com/groupon/jtier/Life.java
+++ b/src/main/java/com/groupon/jtier/Life.java
@@ -92,18 +92,28 @@ class Life {
 
     }
 
-    void onCancel(final Runnable runnable) {
+    Disposable onCancel(final Runnable runnable) {
         if (isCancelled()) {
             runnable.run();
-            return;
+            return () -> {};
         }
 
         this.lock.lock();
         try {
             this.cancelListeners.add(runnable);
-        } finally {
+        }
+        finally {
             this.lock.unlock();
         }
+        return () -> {
+            this.lock.lock();
+            try {
+                this.cancelListeners.remove(runnable);
+            }
+            finally {
+                this.lock.unlock();
+            }
+        };
     }
 
     private enum State {

--- a/src/test/java/com/groupon/jtier/LifeEventsTest.java
+++ b/src/test/java/com/groupon/jtier/LifeEventsTest.java
@@ -41,6 +41,25 @@ public class LifeEventsTest {
     }
 
     @Test
+    public void testCancelEventDisposes() throws Exception {
+        final Ctx d = Ctx.empty();
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean canceled = new AtomicBoolean(false);
+
+        Disposable disposable = d.onCancel(() -> {
+            canceled.set(true);
+            latch.countDown();
+        });
+        
+        disposable.dispose();
+        
+        d.cancel();
+
+        assertThat(latch.await(20, TimeUnit.MILLISECONDS)).isFalse();
+        assertThat(canceled.get()).isFalse();
+    }
+
+    @Test
     public void testCancelParentCancelsChildren() throws Exception {
         final Ctx p = Ctx.empty();
         final Ctx c = p.createChild();


### PR DESCRIPTION
Provides a facility to dispose callbacks registered via onCancel/onAttach/onDetach.

* No documentation change (no reference to f.e. onCancel).
* No source changes needed in clients.
* `mvn clean verify` tested.
* POM minor version bumped, as the binary API changes in a non-backwards-compatible way
