### PR TITLE
Continuation of Ctx semantic improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 * **BREAKING** Change `close()` to be `cancel(null)` instead of detach.
 * **BREAKING** A thread *always* has a `Ctx`, detach causes a new empty to be attached.
+* Contexts are no longer immutable.  Although the API hasn't changed and there is still no locking for reads, there
+  is no longer a need to worry about `Ctx` references changing every time a value gets added.
 * Add `Ctx#cancel(Throwable)` to cancel with a cause
 * Add `Ctx#detach` to replace `Ctx#close` for detaching a Ctx
 * Add `Ctx.Key#get` and `Ctx.Key#set` convenience operations
+* Add `Ctx#with(Map<String, T>, Class<T>)` for quickly setting values from a map
+* Add `Ctx#add(Map<String, T>, Class<T>)` alias to `Ctx#with(Map<String, T>, Class<T>)` for more elegant Fluent phrasing
+* Add `Ctx#isEmpty` to determine if a context has any values set
+* Add `Ctx#create` alias to `Ctx#empty` for more elegant Fluent phrasing
+* Add `Ctx#add(Key<T>, T)` alias to `Ctx#with` for more elegant Fluent phrasing
 
 # 0.3.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
             <version>2.1.9</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -98,6 +104,18 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>20.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>5.0.7.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>5.0.7.RELEASE</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This incorporates the changes in #3 and #5 and adds further usability enhancements, including:

* Contexts are no longer immutable.  Although the API hasn't changed and there is still no locking for reads, there is no longer a need to worry about `Ctx` references changing every time a value gets added.
* Add `Ctx#cancel(Throwable)` to cancel with a cause
* Add `Ctx#detach` to replace `Ctx#close` for detaching a Ctx
* Add `Ctx.Key#get` and `Ctx.Key#set` convenience operations
* Add `Ctx#with(Map<String, T>, Class<T>)` for quickly setting values from a map
* Add `Ctx#add(Map<String, T>, Class<T>)` alias to `Ctx#with(Map<String, T>, Class<T>)` for more elegant Fluent phrasing
* Add `Ctx#isEmpty` to determine if a context has any values set
* Add `Ctx#create` alias to `Ctx#empty` for more elegant Fluent phrasing
* Add `Ctx#add(Key<T>, T)` alias to `Ctx#with` for more elegant Fluent phrasing