### PR TITLE
Initial ThreadGlobal sketch

### DIFF
--- a/src/main/java/com/groupon/jtier/global/GlobalPropagatingCallable.java
+++ b/src/main/java/com/groupon/jtier/global/GlobalPropagatingCallable.java
@@ -1,0 +1,34 @@
+package com.groupon.jtier.global;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+/**
+ * Wraps a delegate {@link Callable} to provide a set of {@link ThreadGlobal} values.
+ *
+ * @param <V>  The type of value to be returned by {@link #call()}.
+ */
+public class GlobalPropagatingCallable<V> implements Callable<V> {
+
+    private Callable<V>       target;
+    private Map<String, ?> globalValues;
+
+    /**
+     * Constructor.
+     *
+     * @param target        The delegate callable.
+     * @param globalValues  The values to put into the callable's {@link ThreadGlobal}.
+     */
+    public GlobalPropagatingCallable(Callable<V> target, Map<String, ?> globalValues) {
+        this.target = target;
+        this.globalValues = globalValues;
+    }
+
+    @Override
+    public V call() throws Exception {
+        for (Map.Entry<String, ?> entry: globalValues.entrySet()) {
+            ThreadGlobal.value(entry.getKey(), Object.class).set(entry.getValue());
+        }
+        return target.call();
+    }
+}

--- a/src/main/java/com/groupon/jtier/global/GlobalPropagatingExecutorService.java
+++ b/src/main/java/com/groupon/jtier/global/GlobalPropagatingExecutorService.java
@@ -1,0 +1,73 @@
+package com.groupon.jtier.global;
+
+
+import java.util.Map;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * Provides a {@link ExecutorService} that propagates {@link ThreadGlobal} values from the current thread to newly
+ * spawned threads.
+ */
+public class GlobalPropagatingExecutorService extends ThreadPoolExecutor {
+
+    public GlobalPropagatingExecutorService(int corePoolSize,
+                                            int maximumPoolSize,
+                                            long keepAliveTime,
+                                            TimeUnit unit,
+                                            BlockingQueue<Runnable> workQueue) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    public GlobalPropagatingExecutorService(int corePoolSize,
+                                            int maximumPoolSize,
+                                            long keepAliveTime,
+                                            TimeUnit unit,
+                                            BlockingQueue<Runnable> workQueue,
+                                            ThreadFactory threadFactory) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    }
+
+    public GlobalPropagatingExecutorService(int corePoolSize,
+                                            int maximumPoolSize,
+                                            long keepAliveTime,
+                                            TimeUnit unit,
+                                            BlockingQueue<Runnable> workQueue,
+                                            RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    }
+
+    public GlobalPropagatingExecutorService(int corePoolSize,
+                                            int maximumPoolSize,
+                                            long keepAliveTime,
+                                            TimeUnit unit,
+                                            BlockingQueue<Runnable> workQueue,
+                                            ThreadFactory threadFactory,
+                                            RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+        Map<String, ?> globalValues = ThreadGlobal.dumpValues();
+        Runnable wrapper = new GlobalPropagatingRunnable (runnable, globalValues);
+
+        return super.newTaskFor(wrapper, value);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Callable<T> callable) {
+        Map<String, ?> globalValues = ThreadGlobal.dumpValues();
+        Callable<T> wrapper = new GlobalPropagatingCallable<>(callable, globalValues);
+
+        return super.newTaskFor(wrapper);
+    }
+}

--- a/src/main/java/com/groupon/jtier/global/GlobalPropagatingRunnable.java
+++ b/src/main/java/com/groupon/jtier/global/GlobalPropagatingRunnable.java
@@ -1,0 +1,31 @@
+package com.groupon.jtier.global;
+
+import java.util.Map;
+
+/**
+ * Wraps a delegate {@link Runnable} to provide a set of {@link ThreadGlobal} values.
+ */
+public class GlobalPropagatingRunnable implements Runnable {
+
+    private Runnable       target;
+    private Map<String, ?> globalValues;
+
+    /**
+     * Constructor.
+     *
+     * @param target        The delegate runnable.
+     * @param globalValues  The values to put into the runnable's {@link ThreadGlobal}.
+     */
+    public GlobalPropagatingRunnable(Runnable target, Map<String, ?> globalValues) {
+        this.target = target;
+        this.globalValues = globalValues;
+    }
+
+    @Override
+    public void run() {
+        for (Map.Entry<String, ?> entry: globalValues.entrySet()) {
+            ThreadGlobal.value(entry.getKey(), Object.class).set(entry.getValue());
+        }
+        target.run();
+    }
+}

--- a/src/main/java/com/groupon/jtier/global/ThreadGlobal.java
+++ b/src/main/java/com/groupon/jtier/global/ThreadGlobal.java
@@ -1,57 +1,75 @@
 package com.groupon.jtier.global;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.WeakHashMap;
 
 
+/**
+ * Provides a bag of global variables for a given thread, with support for dumping values so that they may be exported
+ * to other threads without concern of non-deterministic behavior.  See the classes mentioned below if you're looking
+ * to export global values across thread boundaries.
+ *
+ * @see   GlobalPropagatingExecutorService
+ * @see   GlobalPropagatingCallable
+ * @see   GlobalPropagatingRunnable
+ * @param <T>   The value type.
+ */
 public class ThreadGlobal<T> extends InheritableThreadLocal<T> {
 
-    private static InheritableThreadLocal<Map<ThreadGlobal<?>, ?>> globals = new InheritableThreadLocal<Map<ThreadGlobal<?>, ?>>() {
+    private static InheritableThreadLocal<Map<String, ThreadGlobal<?>>> globals = new InheritableThreadLocal<Map<String, ThreadGlobal<?>>>() {
         @Override
-        protected Map<ThreadGlobal<?>, ?> initialValue() {
+        protected Map<String, ThreadGlobal<?>> initialValue() {
             return new WeakHashMap<>();
         }
 
         @Override
-        protected Map<ThreadGlobal<?>, ?> childValue(Map<ThreadGlobal<?>, ?> parentValue) {
+        protected Map<String, ThreadGlobal<?>> childValue(Map<String, ThreadGlobal<?>> parentValue) {
             return new WeakHashMap<>(parentValue);
         }
     };
 
     @SuppressWarnings("unchecked cast")
     public static <T> ThreadGlobal<T> value(String key, Class<T> valueType) {
-        return globals.get().containsKey(key) ? (ThreadGlobal<T>)globals.get().get(key) : new ThreadGlobal<T>();
+        return globals.get().containsKey(key) ? (ThreadGlobal<T>)globals.get().get(key) : new ThreadGlobal<T>(key);
     }
 
     public static void clear() {
-        Map<ThreadGlobal<?>, ?> newGlobals = new WeakHashMap<>();
+        Map<String, ThreadGlobal<?>> newGlobals = new WeakHashMap<>();
         globals.set(newGlobals);
     }
 
     public static Map<String, ?> dumpValues() {
-        return null;
+        Map<String, Object> values = new HashMap<>(globals.get().size());
+        for (Map.Entry<String, ThreadGlobal<?>> globalEntry: globals.get().entrySet()) {
+            values.put(globalEntry.getKey(), globalEntry.getValue().get());
+        }
+
+        return values;
     }
+
+    private String name;
 
     /**
-     * Propagates the current thread's global values to a given runnable.
+     * Constructor.
      *
-     * @return   The wrapped runnable with global values attached.
+     * @param name   The variable name.
      */
-    public static Runnable propagate(Runnable target) {
-        Map<String, ?> values = dumpValues();
-        return new GlobalPropagatingRunnable (target, values);
+    private ThreadGlobal(String name) {
+        super();
+        this.name = name;
     }
 
-    private ThreadGlobal() {
-        super();
+    public String getName() {
+        return name;
     }
 
     @Override
     public void set(T value) {
         super.set(value);
 
-        Map<ThreadGlobal<?>, ?> newGlobals = new WeakHashMap<>(globals.get());
-        newGlobals.put(this, null);
+        Map<String, ThreadGlobal<?>> newGlobals = new WeakHashMap<>(globals.get());
+        newGlobals.put(this.getName(), this);
         globals.set(newGlobals);
     }
 }

--- a/src/main/java/com/groupon/jtier/global/ThreadGlobal.java
+++ b/src/main/java/com/groupon/jtier/global/ThreadGlobal.java
@@ -1,0 +1,57 @@
+package com.groupon.jtier.global;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+
+public class ThreadGlobal<T> extends InheritableThreadLocal<T> {
+
+    private static InheritableThreadLocal<Map<ThreadGlobal<?>, ?>> globals = new InheritableThreadLocal<Map<ThreadGlobal<?>, ?>>() {
+        @Override
+        protected Map<ThreadGlobal<?>, ?> initialValue() {
+            return new WeakHashMap<>();
+        }
+
+        @Override
+        protected Map<ThreadGlobal<?>, ?> childValue(Map<ThreadGlobal<?>, ?> parentValue) {
+            return new WeakHashMap<>(parentValue);
+        }
+    };
+
+    @SuppressWarnings("unchecked cast")
+    public static <T> ThreadGlobal<T> value(String key, Class<T> valueType) {
+        return globals.get().containsKey(key) ? (ThreadGlobal<T>)globals.get().get(key) : new ThreadGlobal<T>();
+    }
+
+    public static void clear() {
+        Map<ThreadGlobal<?>, ?> newGlobals = new WeakHashMap<>();
+        globals.set(newGlobals);
+    }
+
+    public static Map<String, ?> dumpValues() {
+        return null;
+    }
+
+    /**
+     * Propagates the current thread's global values to a given runnable.
+     *
+     * @return   The wrapped runnable with global values attached.
+     */
+    public static Runnable propagate(Runnable target) {
+        Map<String, ?> values = dumpValues();
+        return new GlobalPropagatingRunnable (target, values);
+    }
+
+    private ThreadGlobal() {
+        super();
+    }
+
+    @Override
+    public void set(T value) {
+        super.set(value);
+
+        Map<ThreadGlobal<?>, ?> newGlobals = new WeakHashMap<>(globals.get());
+        newGlobals.put(this, null);
+        globals.set(newGlobals);
+    }
+}

--- a/src/test/java/com/groupon/jtier/ThreadGlobalTest.java
+++ b/src/test/java/com/groupon/jtier/ThreadGlobalTest.java
@@ -1,0 +1,10 @@
+package com.groupon.jtier;
+
+import org.junit.Test;
+
+public class ThreadGlobalTest {
+    @Test
+    public void testSingleThreadedValuePersistance() {
+
+    }
+}


### PR DESCRIPTION
Here is a sketch of a ThreadGlobal concept that is always bound to the current thread.  We add a utility callable and runnable class, as well as an `ExecutorService` that will handle unbinding values from the current thread for passing onto new threads.

This provides mutability inside a single thread and immutability to other threads, hopefully addressing concerns with opening up mutability in Ctx #6 .